### PR TITLE
Add telepresence login as prerequisuite for intercepts

### DIFF
--- a/howtos/intercepts.md
+++ b/howtos/intercepts.md
@@ -15,7 +15,7 @@ For a detailed walk-though on creating intercepts using our sample app, follow t
 
 ## Prerequisites
 
-Before you begin, you need to have [Telepresence installed](<../../install/), and either the Kubernetes command-line tool, [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/), or the OpenShift Container Platform command-line interface, [`oc`](https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli_cli-developer-commands). This document uses kubectl in all example commands. OpenShift users can substitute oc [commands instead](https://docs.openshift.com/container-platform/4.1/cli_reference/developer-cli-commands.html).
+Before you begin, you need to have [Telepresence installed](<../../install/), and either the Kubernetes command-line tool, [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/), or the OpenShift Container Platform command-line interface, [`oc`](https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli_cli-developer-commands). This document uses kubectl in all example commands. OpenShift users can substitute oc [commands instead](https://docs.openshift.com/container-platform/4.1/cli_reference/developer-cli-commands.html). You will also need an [Ambassador Cloud](../../../../../) account and authenticated telepresence with `telepresence login`.
 
 This guide assumes you have a Kubernetes deployment and service accessible publicly by an ingress controller, and that you can run a copy of that service on your laptop.
 


### PR DESCRIPTION
Without `telepresence login`, `telepresence connect` did not work and the error message was not clear that it was an authentication issue. Once `telepresence login` was run, `telepresence connect` worked without any issues. I feel it would be clear if the docs mentioned that we have to login before we connect our cluster although that is intuitive.